### PR TITLE
Pass Command-W on the iPad hardware keyboard to the emulated Mac

### DIFF
--- a/BasiliskII/src/iOS/BasiliskII/B2ViewController.mm
+++ b/BasiliskII/src/iOS/BasiliskII/B2ViewController.mm
@@ -39,6 +39,16 @@ static B2ViewController *_sharedB2ViewController = nil;
     CGSize initialScreenSize;
 }
 
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+    if (action == NSSelectorFromString(@"_performClose:")) {
+        // Blocks Command-W from closing all of Basilisk II
+        return true;
+    }
+    return [super canPerformAction:action withSender:sender];
+}
+
+
 + (instancetype)sharedViewController {
     return _sharedB2ViewController;
 }


### PR DESCRIPTION
This resolves the issue discussed here: https://www.emaculation.com/forum/viewtopic.php?p=75181#p75181

In short, the iOS multitasking environment interprets `⌘-W` on the iPad hardware keyboard as a signal from the user to close the app and go back to the home screen. This change intercepts that event and tells the system, "nah, we got that command handled, thanks."